### PR TITLE
#1; Git Branch-Specific Bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ While Vim's native marks (`ma`, `'a`) are useful for temporary navigation, `book
 |-----------------|----------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
 | **Storage**     | Plain text (`.viminfo`/`shada`)                    | **SQLite Database** for structured, queryable, and persistent storage                                     |
 | **Scope**       | Local (per-file) or Global (cross-file)            | **Project-aware**: Bookmarks are tied to a project root                                                   |
+| **Branch-specific** | No                                              | **Yes**: Bookmarks can be isolated per Git branch and toggled at runtime                                  |
 | **Data**        | File path, line, and column only                    | **Rich metadata**: line content, timestamp, project info                                                  |
 | **UI**          | Command-based (`:marks`)                            | **Interactive UI**: Telescope integration for fuzzy search, browsing, and live previews                   |
 | **Persistence** | Only global marks (`A-Z`) persist across sessions   | **All bookmarks are persistent** by default                                                               |
@@ -79,6 +80,9 @@ require("bookmarks").setup({
     -- Storage configuration
     db_path = vim.fn.stdpath('data') .. '/bookmarks.db',  -- Path to SQLite database
 
+    -- Branch configuration
+    use_branch_specific = false,  -- Enable/disable branch-specific bookmarks (can be toggled at runtime)
+
     -- Keymaps configuration
     default_mappings = true,  -- Set to false to disable default keymaps
 
@@ -98,6 +102,7 @@ require("bookmarks").setup({
 - `:BookmarkAdd` - Add bookmark at current line
 - `:BookmarkRemove` - Remove bookmark at current line
 - `:Bookmarks` - Open Telescope to browse bookmarks
+- `:BookmarksToggleBranchScope` - Toggle branch-specific bookmarks on/off
 
 ### Default Keymaps
 
@@ -106,6 +111,7 @@ require("bookmarks").setup({
 - `<leader>bj` - Jump to next bookmark in file
 - `<leader>bk` - Jump to previous bookmark in file
 - `<leader>bl` - List bookmarks (opens Telescope)
+- `<leader>bt` - Toggle branch-specific bookmarks on/off
 
 Inside Telescope bookmarks view:
 - `<CR>` - Jump to selected bookmark
@@ -190,4 +196,46 @@ The bookmarks viewer features a vertical layout with:
 - File preview at the top, with syntax highlighting and a visual indicator for the bookmarked line
 - Bookmark list in the middle showing line numbers, filenames, and bookmark content
 - Search prompt at the bottom for quick filtering
+
+## Branch-Specific Bookmarks
+
+When `use_branch_specific` is enabled, bookmarks are stored and shown per Git branch. This means:
+- You only see bookmarks for the current branch in both buffer and Telescope views.
+- Bookmarks added on one branch are not visible on another branch.
+- When toggled off, all bookmarks (regardless of branch) are shown.
+- You can toggle this at runtime with `:BookmarksToggleBranchScope` or `<leader>bt`.
+
+This is useful for workflows where you want to keep bookmarks isolated to specific features or tasks per branch.
+
+## Statusline Helper
+
+You can show the current bookmarks scope (global or branch) in your statusline using the built-in helper:
+
+### Vanilla Neovim
+
+Add this to your `init.lua`:
+
+```lua
+vim.o.statusline = "%f %h%m%r %=%{v:lua.require('bookmarks').status()}"
+```
+
+### lualine.nvim
+
+If you use [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim):
+
+```lua
+require('lualine').setup {
+  sections = {
+    lualine_c = {
+      'filename',
+      { function() return require('bookmarks').status() end }
+    },
+    -- ... other sections ...
+  }
+}
+```
+
+This will show `Bookmarks: branch=my-feature` or `Bookmarks: global` in your statusline, depending on the current mode.
+
+---
 

--- a/lua/bookmarks/commands.lua
+++ b/lua/bookmarks/commands.lua
@@ -1,10 +1,17 @@
 local Commands = {}
 local Navigation = require('bookmarks.navigation')
 local storage = require('bookmarks.storage')
+local utils = require('bookmarks.utils')
 
 function Commands.add_bookmark()
     local bufnr, filename, line, project_root = Navigation.get_context()
     local content = vim.api.nvim_buf_get_lines(bufnr, line - 1, line, false)[1]
+
+    local config = require('bookmarks').get_config()
+    local branch = nil
+    if config.use_branch_specific then
+        branch = utils.get_current_branch()
+    end
 
     storage.add_bookmark({
         filename = filename,
@@ -12,6 +19,7 @@ function Commands.add_bookmark()
         content = content,
         timestamp = os.time(),
         project_root = project_root,
+        branch = branch,
     })
 
     vim.notify('Bookmark added', vim.log.levels.INFO)
@@ -20,7 +28,12 @@ end
 
 function Commands.remove_bookmark()
     local bufnr, filename, line, project_root = Navigation.get_context()
-    storage.remove_bookmark(filename, line, project_root)
+    local config = require('bookmarks').get_config()
+    local branch = nil
+    if config.use_branch_specific then
+        branch = utils.get_current_branch()
+    end
+    storage.remove_bookmark(filename, line, project_root, branch)
 
     vim.notify('Bookmark removed', vim.log.levels.INFO)
     return bufnr

--- a/lua/bookmarks/init.lua
+++ b/lua/bookmarks/init.lua
@@ -1,67 +1,105 @@
 local M = {}
 
+-- Plugin configuration
+local config = nil
+
+-- Default configuration
+local default_config = {
+    db_path = vim.fn.stdpath('data') .. '/bookmarks.db',
+    use_branch_specific = false, -- Enable/disable branch-specific bookmarks
+    default_mappings = true,     -- Enable default keymaps
+}
+
+-- Validate configuration options
+local function validate_config(opts)
+    if opts.default_scope and not vim.tbl_contains({ "global", "branch" }, opts.default_scope) then
+        vim.notify("Invalid default_scope. Must be 'global' or 'branch'", vim.log.levels.WARN)
+        opts.default_scope = "global"
+    end
+
+    if opts.default_list and type(opts.default_list) ~= "string" then
+        vim.notify("Invalid default_list. Must be a string", vim.log.levels.WARN)
+        opts.default_list = "main"
+    end
+
+    if opts.use_branch_specific then
+        local utils = require('bookmarks.utils')
+        if not utils.is_git_repo() then
+            vim.notify(
+                "[bookmarks.nvim] use_branch_specific is true, but this is not a Git repo. Falling back to global bookmarks.",
+                vim.log.levels.WARN)
+            opts.use_branch_specific = false
+        end
+    end
+    return opts
+end
+
+-- Get current configuration
+function M.get_config()
+    return config
+end
+
+function M.toggle_branch_scope()
+    local utils = require('bookmarks.utils')
+    if not config.use_branch_specific then
+        -- Turning ON branch-specific mode
+        if not utils.is_git_repo() then
+            vim.notify("[bookmarks.nvim] Not a Git repo. Cannot enable branch-specific bookmarks. Falling back to global.", vim.log.levels.WARN)
+            config.use_branch_specific = false
+            require('bookmarks.autocmds').refresh_all_buffers()
+            return
+        end
+        local branch = utils.get_current_branch()
+        if not branch or branch == "" then
+            vim.notify("[bookmarks.nvim] No valid branch detected. Cannot enable branch-specific bookmarks. Falling back to global.", vim.log.levels.WARN)
+            config.use_branch_specific = false
+            require('bookmarks.autocmds').refresh_all_buffers()
+            return
+        end
+        config.use_branch_specific = true
+        vim.notify("Branch-specific bookmarks: ON (" .. branch .. ")", vim.log.levels.INFO)
+    else
+        -- Turning OFF branch-specific mode
+        config.use_branch_specific = false
+        vim.notify("Branch-specific bookmarks: OFF (showing all bookmarks)", vim.log.levels.INFO)
+    end
+    require('bookmarks.autocmds').refresh_all_buffers()
+end
+
+function M.status()
+    local utils = require('bookmarks.utils')
+    if config and config.use_branch_specific then
+        local branch = utils.get_current_branch()
+        if branch and branch ~= "" then
+            return "Bookmarks: branch=" .. branch
+        else
+            return "Bookmarks: branch=?"
+        end
+    else
+        return "Bookmarks: global"
+    end
+end
 
 function M.setup(opts)
-    opts = opts or {}
-    if not require('bookmarks.storage').setup(opts) then
+    -- Validate and merge user config with defaults
+    opts = validate_config(opts or {})
+    config = vim.tbl_deep_extend('force', default_config, opts)
+
+    -- Initialize storage with only the storage-specific config
+    local storage_config = {
+        db_path = config.db_path
+    }
+    if not require('bookmarks.storage').setup(storage_config) then
         return
     end
 
-    require('bookmarks.decorations').setup(opts)
+    require('bookmarks.decorations').setup(config)
     local autocmds = require('bookmarks.autocmds')
-    local navigation = require('bookmarks.navigation')
+    local keymaps = require('bookmarks.keymaps')
     autocmds.setup()
+    keymaps.setup(config, autocmds)
 
-
-
-    if opts.default_mappings ~= false then
-        vim.keymap.set('n', '<leader>ba', function()
-            local bufnr = require('bookmarks.commands').add_bookmark()
-            autocmds.refresh_buffer(bufnr)
-        end, { desc = 'Add bookmark' })
-
-        vim.keymap.set('n', '<leader>br', function()
-            local bufnr = require('bookmarks.commands').remove_bookmark()
-            autocmds.refresh_buffer(bufnr)
-        end, { desc = 'Remove bookmark' })
-
-        vim.keymap.set('n', '<leader>bj', function()
-            local bufnr = vim.api.nvim_get_current_buf()
-            local bookmarks = autocmds.get_buffer_bookmarks(bufnr)
-            navigation.jump_to_next(bookmarks)
-        end, { desc = 'Jump to next bookmark in file' })
-
-        vim.keymap.set('n', '<leader>bk', function()
-            local bufnr = vim.api.nvim_get_current_buf()
-            local bookmarks = autocmds.get_buffer_bookmarks(bufnr)
-            navigation.jump_to_prev(bookmarks)
-        end, { desc = 'Jump to prev bookmark in file' })
-
-        vim.keymap.set('n', '<leader>bl',
-            require('telescope').extensions.bookmarks.list,
-            { desc = 'List bookmarks' }
-        )
-    elseif opts.mappings then
-        -- Custom mappings setup
-        if opts.mappings.add then
-            vim.keymap.set('n', opts.mappings.add, function()
-                local bufnr = require('bookmarks.commands').add_bookmark()
-                require('bookmarks.autocmds').refresh_buffer(bufnr)
-            end, { desc = 'Add bookmark' })
-        end
-        if opts.mappings.delete then
-            vim.keymap.set('n', opts.mappings.delete, function()
-                local bufnr = require('bookmarks.commands').remove_bookmark()
-                require('bookmarks.autocmds').refresh_buffer(bufnr)
-            end, { desc = 'Remove bookmark' })
-        end
-        if opts.mappings.list then
-            vim.keymap.set('n', opts.mappings.list,
-                require('telescope').extensions.bookmarks.list,
-                { desc = 'List bookmarks' }
-            )
-        end
-    end
+    require('bookmarks.navigation')
 end
 
 return M

--- a/lua/bookmarks/keymaps.lua
+++ b/lua/bookmarks/keymaps.lua
@@ -1,0 +1,60 @@
+local M = {}
+
+function M.setup(config, autocmds)
+    -- Default keymaps
+    if config.default_mappings ~= false then
+        vim.keymap.set('n', '<leader>ba', function()
+            local bufnr = require('bookmarks.commands').add_bookmark()
+            autocmds.refresh_buffer(bufnr)
+        end, { desc = 'Add bookmark' })
+
+        vim.keymap.set('n', '<leader>br', function()
+            local bufnr = require('bookmarks.commands').remove_bookmark()
+            autocmds.refresh_buffer(bufnr)
+        end, { desc = 'Remove bookmark' })
+
+        vim.keymap.set('n', '<leader>bj', function()
+            local bufnr = vim.api.nvim_get_current_buf()
+            local bookmarks = autocmds.get_buffer_bookmarks(bufnr)
+            require('bookmarks.navigation').jump_to_next(bookmarks)
+        end, { desc = 'Jump to next bookmark in file' })
+
+        vim.keymap.set('n', '<leader>bk', function()
+            local bufnr = vim.api.nvim_get_current_buf()
+            local bookmarks = autocmds.get_buffer_bookmarks(bufnr)
+            require('bookmarks.navigation').jump_to_prev(bookmarks)
+        end, { desc = 'Jump to prev bookmark in file' })
+
+        vim.keymap.set('n', '<leader>bl',
+            require('telescope').extensions.bookmarks.list,
+            { desc = 'List bookmarks' }
+        )
+
+        vim.keymap.set('n', '<leader>bt', function()
+            require('bookmarks').toggle_branch_scope()
+        end, { desc = 'Toggle branch-specific bookmarks' })
+    elseif config.mappings then
+        -- Custom mappings setup
+        if config.mappings.add then
+            vim.keymap.set('n', config.mappings.add, function()
+                local bufnr = require('bookmarks.commands').add_bookmark()
+                require('bookmarks.autocmds').refresh_buffer(bufnr)
+            end, { desc = 'Add bookmark' })
+        end
+        if config.mappings.delete then
+            vim.keymap.set('n', config.mappings.delete, function()
+                local bufnr = require('bookmarks.commands').remove_bookmark()
+                require('bookmarks.autocmds').refresh_buffer(bufnr)
+            end, { desc = 'Remove bookmark' })
+        end
+        if config.mappings.list then
+            vim.keymap.set('n', config.mappings.list,
+                require('telescope').extensions.bookmarks.list,
+                { desc = 'List bookmarks' }
+            )
+        end
+    end
+end
+
+return M
+

--- a/lua/bookmarks/storage.lua
+++ b/lua/bookmarks/storage.lua
@@ -5,8 +5,62 @@ local db = nil
 
 -- Default configuration
 local default_config = {
-    db_path = vim.fn.stdpath('data') .. '/bookmarks.db'
+    db_path = vim.fn.stdpath('data') .. '/bookmarks.db',
+    debug = false
 }
+
+local function debug_print(...)
+    if config and config.debug then
+        print("[bookmarks.nvim]", ...)
+    end
+end
+
+-- Utility: Check if a column exists in the bookmarks table
+local function column_exists(db, column_name)
+    local has_column = false
+    local ok, result = pcall(function()
+        local res = db:eval("PRAGMA table_info(bookmarks)")
+        debug_print("PRAGMA table_info(bookmarks) result:", vim.inspect(res))
+        if type(res) == "table" then
+            for _, row in ipairs(res) do
+                debug_print("Checking column:", row.name)
+                if row.name == column_name then
+                    has_column = true
+                    break
+                end
+            end
+        end
+    end)
+    debug_print("column_exists for", column_name, has_column)
+    return has_column
+end
+
+-- Safe migration: Add columns if they do not exist
+local function safe_migrate_bookmarks_table(db)
+    debug_print("Running safe migration for bookmarks table")
+    if not column_exists(db, "branch") then
+        debug_print("Adding 'branch' column...")
+        local ok, err = pcall(function()
+            db:eval("ALTER TABLE bookmarks ADD COLUMN branch TEXT;")
+        end)
+        if not ok then
+            debug_print("Error adding 'branch' column:", err)
+        end
+    else
+        debug_print("'branch' column already exists")
+    end
+    if not column_exists(db, "list") then
+        debug_print("Adding 'list' column...")
+        local ok, err = pcall(function()
+            db:eval("ALTER TABLE bookmarks ADD COLUMN list TEXT;")
+        end)
+        if not ok then
+            debug_print("Error adding 'list' column:", err)
+        end
+    else
+        debug_print("'list' column already exists")
+    end
+end
 
 -- Initialize the database and create tables
 local function init_database()
@@ -74,20 +128,22 @@ local function init_database()
         return false
     end
 
+    -- Run safe migration for new columns
+    safe_migrate_bookmarks_table(db)
+
     return true
 end
 
-function M.setup(opts)
-    -- Merge user config with defaults
-    config = vim.tbl_deep_extend('force', default_config, opts or {})
 
+function M.setup(opts)
+    opts = opts or {}
+    config = vim.tbl_deep_extend('force', default_config, opts)
     -- Initialize database and create tables
     local success = init_database()
     if not success then
         vim.notify("Failed to initialize bookmarks database", vim.log.levels.ERROR)
         return false
     end
-
     return true
 end
 
@@ -103,7 +159,8 @@ function M.add_bookmark(bookmark)
             line_nr      = bookmark.line,
             content      = bookmark.content,
             timestamp    = bookmark.timestamp,
-            project_root = bookmark.project_root
+            project_root = bookmark.project_root,
+            branch       = bookmark.branch,
         })
     end)
 
@@ -114,18 +171,22 @@ function M.add_bookmark(bookmark)
     return true
 end
 
-function M.remove_bookmark(filename, line, project_root)
+function M.remove_bookmark(filename, line, project_root, branch)
     if not db or not db.bookmarks then
         vim.notify("Database not initialized", vim.log.levels.ERROR)
         return false
     end
 
     local success, err = pcall(function()
-        db.bookmarks:remove({
+        local conditions = {
             filename     = filename,
             line_nr      = line,
             project_root = project_root
-        })
+        }
+        if branch then
+            conditions.branch = branch
+        end
+        db.bookmarks:remove(conditions)
     end)
 
     if not success then
@@ -135,7 +196,7 @@ function M.remove_bookmark(filename, line, project_root)
     return true
 end
 
-function M.get_bookmarks(project_root)
+function M.get_bookmarks(project_root, branch)
     if not db or not db.bookmarks then
         vim.notify("Database not initialized", vim.log.levels.ERROR)
         return {}
@@ -144,6 +205,9 @@ function M.get_bookmarks(project_root)
     local success, results = pcall(function()
         if project_root and project_root ~= "" then
             local query = string.format("SELECT * FROM bookmarks WHERE project_root = '%s'", project_root)
+            if branch then
+                query = query .. string.format(" AND branch = '%s'", branch)
+            end
             return db:eval(query)
         else
             return db.bookmarks:get()
@@ -166,14 +230,15 @@ function M.get_bookmarks(project_root)
             line         = row.line_nr,
             content      = row.content,
             timestamp    = row.timestamp,
-            project_root = row.project_root
+            project_root = row.project_root,
+            branch       = row.branch,
         })
     end
 
     return bookmarks
 end
 
-function M.get_file_bookmarks(filename, project_root)
+function M.get_file_bookmarks(filename, project_root, branch)
     if not db or not db.bookmarks then
         vim.notify("Database not initialized", vim.log.levels.ERROR)
         return {}
@@ -185,6 +250,9 @@ function M.get_file_bookmarks(filename, project_root)
             filename,
             project_root
         )
+        if branch then
+            query = query .. string.format(" AND branch = '%s'", branch)
+        end
         return db:eval(query)
     end)
 
@@ -201,6 +269,7 @@ function M.get_file_bookmarks(filename, project_root)
             content      = row.content,
             timestamp    = row.timestamp,
             project_root = row.project_root,
+            branch       = row.branch,
         })
     end
 

--- a/lua/bookmarks/utils.lua
+++ b/lua/bookmarks/utils.lua
@@ -24,5 +24,28 @@ function Utils.is_special_buff(bufnr)
     end
 end
 
+local function handle_git_command(command)
+    local handle = io.popen(command .. " 2>/dev/null")
+    if handle then
+        local result = handle:read("*l")
+        handle:close()
+        return result and result == "true"
+    end
+end
+
+function Utils.is_git_repo()
+    return handle_git_command("git rev-parse --is-inside-work-tree")
+end
+
+function Utils.get_current_branch()
+    local handle = io.popen("git branch --show-current -i 2>/dev/null")
+    if handle then
+        local branch = handle:read("*l")
+        handle:close()
+        return branch and branch ~= "" and branch or nil
+    end
+    return nil
+end
+
 return Utils
 

--- a/lua/telescope/_extensions/bookmarks.lua
+++ b/lua/telescope/_extensions/bookmarks.lua
@@ -14,6 +14,9 @@ local storage      = require("bookmarks.storage")
 local navigation   = require("bookmarks.navigation")
 local autocmds     = require("bookmarks.autocmds")
 
+local config = require('bookmarks').get_config()
+local utils = require('bookmarks.utils')
+
 --------------------------------------------------------------------------------
 -- Load file for preview
 --------------------------------------------------------------------------------
@@ -209,10 +212,21 @@ end
 local function list_bookmarks(opts)
     opts = opts or {}
 
+    local branch = nil
+    local prompt_title = "Bookmarks (global)"
+    if config.use_branch_specific then
+        branch = utils.get_current_branch()
+        if branch then
+            prompt_title = string.format("Bookmarks (branch: %s)", branch)
+        else
+            prompt_title = "Bookmarks (branch: unknown)"
+        end
+    end
+
     pickers.new(opts, {
-        prompt_title        = "Bookmarks",
+        prompt_title        = prompt_title,
         finder              = finders.new_table({
-            results = storage.get_bookmarks(vim.fn.getcwd()),
+            results = storage.get_bookmarks(vim.fn.getcwd(), branch),
             entry_maker = function(bookmark)
                 return {
                     value   = bookmark,

--- a/plugin/bookmarks.vim
+++ b/plugin/bookmarks.vim
@@ -3,6 +3,7 @@ let g:loaded_bookmarks = 1
 
 command! BookmarkAdd lua require('bookmarks').add_bookmark()
 command! BookmarkRemove lua require('bookmarks').remove_bookmark()
+command! BookmarksToggleBranchScope lua require('bookmarks').toggle_branch_scope()
 command! Bookmarks Telescope bookmarks
 
 lua require('bookmarks')


### PR DESCRIPTION
Add Branch-Specific Bookmarks Functionality
Summary:

- Implements per-branch bookmark isolation: when enabled, only bookmarks for the current Git branch are shown in buffer and Telescope views.
- Adds runtime toggle (:BookmarksToggleBranchScope / <leader>bt) for branch-specific mode.
- Updates Telescope picker to show the current branch in the prompt title.
- Handles edge cases: falls back to global mode and notifies the user if not in a Git repo or branch is invalid.
- Adds a statusline helper (require('bookmarks').status()) to show the current scope.
- Updates README and feature table to document the new functionality.

Why:

- Improves workflow for users working across multiple branches.
- Prevents bookmark clutter and keeps bookmarks relevant to the current context.
- Provides clear UI feedback and robust error handling.

How to use:

- Enable with use_branch_specific = true in setup, or toggle at runtime.
- Use the new statusline helper for instant feedback on current scope.