### PR TITLE
fix: export bookmarks to avoid error calling 'Telescope bookmarks'

### DIFF
--- a/lua/telescope/_extensions/bookmarks.lua
+++ b/lua/telescope/_extensions/bookmarks.lua
@@ -301,6 +301,7 @@ end
 --------------------------------------------------------------------------------
 return telescope.register_extension({
     exports = {
+        bookmarks = list_bookmarks,
         list = list_bookmarks,
     },
 })


### PR DESCRIPTION
When calling `Telescope bookmarks`, I was getting an error.
Looks like, the extension has to export a key with the same name as the extension name for `Telescope bookmarks` to succeed.
Just re-exporting the same function twice: once as `list` , once as `bookmarks` solves the issue.